### PR TITLE
Expand Stadtreinigung job resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# framework
+# QB-Core Stadtreinigung Job
+
+Dieses Repository enthält eine erweiterte Implementierung eines **Stadtreinigung**-Jobs für einen QB-Core-basierten FiveM-Server.
+
+## Installation
+1. Den Ordner `resources/jobs/qb-citycleaning` in das `resources` Verzeichnis des Servers kopieren.
+2. In der `server.cfg` starten:
+   ```
+   ensure qb-citycleaning
+   ```
+3. Job in `qb-core/shared/jobs.lua` eintragen:
+   ```lua
+   ['stadtreinigung'] = {
+       label = 'Stadtreinigung',
+       defaultDuty = true,
+       offDutyPay = false,
+   }
+   ```
+
+## Nutzung
+- Zum Depot laufen und mit `E` das Dienst-Tablet öffnen
+- Dienst beginnen, Fahrzeug anfordern und Uniform anlegen
+- Müllsäcke aufsammeln und Graffiti entfernen
+- Bei vollständiger Reinigung wird ein Bonus ausgezahlt
+
+## Features
+- Dienst-Tablet mit Fahrzeug- und Uniformverwaltung
+- Aufgaben für Müllentsorgung und Graffitientfernung
+- Bonuszahlung bei kompletter Abarbeitung aller Punkte

--- a/resources/jobs/qb-citycleaning/README.md
+++ b/resources/jobs/qb-citycleaning/README.md
@@ -1,0 +1,24 @@
+# qb-citycleaning
+
+Erweiterter Stadtreinigungs-Job für QB-Core.
+
+## Features
+- Dienst-Tablet am Depot (`Config.Depot`)
+- Arbeitsfahrzeuge (Müllwagen/Kehrmaschine) über Tablet abrufbar
+- Uniformen für männliche und weibliche Charaktere
+- Aufgaben: Müllsäcke einsammeln und Graffiti entfernen
+- Bonuszahlung wenn alle Aufgaben erledigt werden
+
+## Installation
+1. Resource in den Ordner `resources/[jobs]/qb-citycleaning` legen
+2. In der `server.cfg` starten: `ensure qb-citycleaning`
+3. Job in `qb-core/shared/jobs.lua` hinzufügen:
+```lua
+['stadtreinigung'] = { label = 'Stadtreinigung', defaultDuty = true, grades = { ['0'] = { name = 'Mitarbeiter', payment = 100 } } }
+```
+
+## Nutzung
+- An das Depot laufen und mit `E` das Tablet öffnen
+- Dienst beginnen, Fahrzeug holen, Uniform anlegen
+- Markierte Müllsäcke und Graffiti mit `E` entfernen
+- Nach Abschluss aller Aufgaben erfolgt eine Bonuszahlung

--- a/resources/jobs/qb-citycleaning/client.lua
+++ b/resources/jobs/qb-citycleaning/client.lua
@@ -1,0 +1,178 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local onDuty = false
+local trashObjects = {}
+local graffitiObjects = {}
+local trashCount, graffitiCount = 0, 0
+
+-- spawn trash bags
+local function spawnTrash()
+    for _, spot in pairs(Config.TrashSpots) do
+        local obj = CreateObjectNoOffset(GetHashKey(Config.TrashModel), spot.x, spot.y, spot.z, false, false, true)
+        PlaceObjectOnGroundProperly(obj)
+        FreezeEntityPosition(obj, true)
+        trashObjects[obj] = true
+        trashCount = trashCount + 1
+    end
+end
+
+-- spawn graffiti objects
+local function spawnGraffiti()
+    for _, spot in pairs(Config.GraffitiSpots) do
+        local obj = CreateObjectNoOffset(GetHashKey(Config.GraffitiModel), spot.x, spot.y, spot.z, false, false, true)
+        PlaceObjectOnGroundProperly(obj)
+        FreezeEntityPosition(obj, true)
+        graffitiObjects[obj] = true
+        graffitiCount = graffitiCount + 1
+    end
+end
+
+local function spawnTasks()
+    trashCount, graffitiCount = 0, 0
+    spawnTrash()
+    spawnGraffiti()
+end
+
+local function cleanupTasks()
+    for obj in pairs(trashObjects) do DeleteObject(obj) end
+    for obj in pairs(graffitiObjects) do DeleteObject(obj) end
+    trashObjects, graffitiObjects = {}, {}
+    trashCount, graffitiCount = 0, 0
+end
+
+-- tablet menu
+local function openTablet()
+    local menu = {
+        {header = 'Stadtreinigung', isMenuHeader = true},
+        {header = onDuty and 'Dienst beenden' or 'Dienst beginnen', params = {event = 'qb-citycleaning:client:ToggleDuty'}},
+        {header = 'Arbeitsfahrzeug holen', params = {event = 'qb-citycleaning:client:SpawnVehicle'}},
+        {header = 'Uniform anlegen', params = {event = 'qb-citycleaning:client:WearUniform'}},
+        {header = 'Uniform ausziehen', params = {event = 'qb-citycleaning:client:RemoveUniform'}},
+        {header = 'Schließen', params = {event = 'qb-menu:client:closeMenu'}}
+    }
+    exports['qb-menu']:openMenu(menu)
+end
+
+CreateThread(function()
+    while true do
+        local ped = PlayerPedId()
+        local pos = GetEntityCoords(ped)
+        local dist = #(pos - Config.Depot)
+        if dist < 2.0 then
+            DrawText3D(Config.Depot.x, Config.Depot.y, Config.Depot.z + 0.5, '[E] Tablet öffnen')
+            if IsControlJustReleased(0, 38) then
+                openTablet()
+            end
+            Wait(0)
+        else
+            Wait(1000)
+        end
+    end
+end)
+
+RegisterNetEvent('qb-citycleaning:client:ToggleDuty', function()
+    TriggerServerEvent('qb-citycleaning:server:toggleDuty')
+end)
+
+RegisterNetEvent('qb-citycleaning:client:SpawnVehicle', function()
+    if not onDuty then
+        QBCore.Functions.Notify('Nicht im Dienst', 'error')
+        return
+    end
+    local model = Config.Vehicles[math.random(#Config.Vehicles)]
+    QBCore.Functions.SpawnVehicle(model, function(veh)
+        SetVehicleNumberPlateText(veh, 'REIN' .. tostring(math.random(100, 999)))
+        SetEntityHeading(veh, Config.VehicleSpawn.w)
+        TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
+    end, Config.VehicleSpawn, true)
+end)
+
+RegisterNetEvent('qb-citycleaning:client:WearUniform', function()
+    local gender = QBCore.Functions.GetPlayerData().charinfo.gender == 0 and 'male' or 'female'
+    TriggerEvent('qb-clothing:client:loadOutfit', Config.Uniforms[gender])
+end)
+
+RegisterNetEvent('qb-citycleaning:client:RemoveUniform', function()
+    TriggerServerEvent('qb-clothing:loadPlayerSkin')
+end)
+
+-- handle job updates
+RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
+    onDuty = job.name == Config.Job
+    if onDuty then
+        spawnTasks()
+    else
+        cleanupTasks()
+    end
+end)
+
+AddEventHandler('onResourceStart', function(resource)
+    if resource ~= GetCurrentResourceName() then return end
+    local playerJob = QBCore.Functions.GetPlayerData().job
+    onDuty = playerJob.name == Config.Job
+    if onDuty then spawnTasks() end
+end)
+
+-- interaction loop
+CreateThread(function()
+    while true do
+        if onDuty then
+            local sleep = 1000
+            local ped = PlayerPedId()
+            local pos = GetEntityCoords(ped)
+            for obj in pairs(trashObjects) do
+                local objPos = GetEntityCoords(obj)
+                local dist = #(pos - objPos)
+                if dist < 2.0 then
+                    sleep = 0
+                    DrawText3D(objPos.x, objPos.y, objPos.z + 1.0, '[E] Müll aufheben')
+                    if IsControlJustReleased(0, 38) then
+                        TaskStartScenarioInPlace(ped, 'WORLD_HUMAN_BUM_WASH', 0, true)
+                        Wait(4000)
+                        ClearPedTasksImmediately(ped)
+                        DeleteObject(obj)
+                        trashObjects[obj] = nil
+                        trashCount = trashCount - 1
+                        TriggerServerEvent('qb-citycleaning:server:reward', 'trash')
+                    end
+                end
+            end
+            for obj in pairs(graffitiObjects) do
+                local objPos = GetEntityCoords(obj)
+                local dist = #(pos - objPos)
+                if dist < 2.0 then
+                    sleep = 0
+                    DrawText3D(objPos.x, objPos.y, objPos.z + 1.0, '[E] Graffiti entfernen')
+                    if IsControlJustReleased(0, 38) then
+                        TaskStartScenarioInPlace(ped, 'WORLD_HUMAN_MAID_CLEAN', 0, true)
+                        Wait(4000)
+                        ClearPedTasksImmediately(ped)
+                        DeleteObject(obj)
+                        graffitiObjects[obj] = nil
+                        graffitiCount = graffitiCount - 1
+                        TriggerServerEvent('qb-citycleaning:server:reward', 'graffiti')
+                    end
+                end
+            end
+            if trashCount == 0 and graffitiCount == 0 and (next(trashObjects) or next(graffitiObjects)) == nil then
+                TriggerServerEvent('qb-citycleaning:server:bonus')
+            end
+            Wait(sleep)
+        else
+            Wait(1000)
+        end
+    end
+end)
+
+function DrawText3D(x, y, z, text)
+    SetDrawOrigin(x, y, z, 0)
+    SetTextScale(0.35, 0.35)
+    SetTextFont(4)
+    SetTextProportional(1)
+    SetTextColour(255, 255, 255, 215)
+    SetTextEntry('STRING')
+    SetTextCentre(1)
+    AddTextComponentString(text)
+    DrawText(0.0, 0.0)
+    ClearDrawOrigin()
+end

--- a/resources/jobs/qb-citycleaning/config.lua
+++ b/resources/jobs/qb-citycleaning/config.lua
@@ -1,0 +1,60 @@
+Config = {}
+
+-- Job name as defined in QB-Core shared/jobs.lua
+Config.Job = 'stadtreinigung'
+
+-- Location for duty tablet
+Config.Depot = vector3(-321.59, -1545.58, 30.72)
+
+-- Vehicle spawn point
+Config.VehicleSpawn = vector4(-333.45, -1539.07, 30.72, 270.0)
+
+-- Available work vehicles
+Config.Vehicles = {'trash', 'sweeper'}
+
+-- Uniform presets
+Config.Uniforms = {
+    male = {
+        ['tshirt_1'] = 59, ['tshirt_2'] = 0,
+        ['torso_1'] = 56, ['torso_2'] = 0,
+        ['arms'] = 41,
+        ['pants_1'] = 36, ['pants_2'] = 0,
+        ['shoes_1'] = 25, ['shoes_2'] = 0,
+        ['helmet_1'] = 62, ['helmet_2'] = 0,
+        ['vest_1'] = 65, ['vest_2'] = 0
+    },
+    female = {
+        ['tshirt_1'] = 36, ['tshirt_2'] = 0,
+        ['torso_1'] = 48, ['torso_2'] = 0,
+        ['arms'] = 36,
+        ['pants_1'] = 35, ['pants_2'] = 0,
+        ['shoes_1'] = 26, ['shoes_2'] = 0,
+        ['helmet_1'] = 62, ['helmet_2'] = 0,
+        ['vest_1'] = 65, ['vest_2'] = 0
+    }
+}
+
+-- Payment range per task
+Config.MinPay = 50
+Config.MaxPay = 100
+Config.BonusPay = 250
+
+-- Locations where trash can spawn
+Config.TrashSpots = {
+    vector3(-324.96, -1531.57, 27.54),
+    vector3(-341.25, -1568.61, 25.23),
+    vector3(-350.96, -1495.83, 30.74)
+}
+
+-- Prop model for trash bags
+Config.TrashModel = 'prop_rub_binbag_sd_01'
+
+-- Locations for graffiti
+Config.GraffitiSpots = {
+    vector3(-325.12, -1524.8, 27.54),
+    vector3(-344.5, -1549.3, 27.74),
+    vector3(-352.1, -1509.1, 29.72)
+}
+
+-- Prop model used as graffiti placeholder
+Config.GraffitiModel = 'prop_fncresidue_01a'

--- a/resources/jobs/qb-citycleaning/fxmanifest.lua
+++ b/resources/jobs/qb-citycleaning/fxmanifest.lua
@@ -1,0 +1,11 @@
+fx_version 'cerulean'
+game 'gta5'
+
+author 'City Cleanup Job Example'
+description 'Stadtreinigung job for QB-Core'
+
+shared_script 'config.lua'
+client_script 'client.lua'
+server_script 'server.lua'
+
+lua54 'yes'

--- a/resources/jobs/qb-citycleaning/server.lua
+++ b/resources/jobs/qb-citycleaning/server.lua
@@ -1,0 +1,48 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+-- Command to toggle the job
+QBCore.Commands.Add('reinigung', 'Starte oder beende den Stadtreinigungsdienst', {}, false, function(source)
+    local Player = QBCore.Functions.GetPlayer(source)
+    if Player.PlayerData.job.name == Config.Job then
+        Player.Functions.SetJob('unemployed', 0)
+        TriggerClientEvent('QBCore:Notify', source, 'Du bist nicht mehr im Dienst.', 'error')
+    else
+        Player.Functions.SetJob(Config.Job, 0)
+        TriggerClientEvent('QBCore:Notify', source, 'Stadtreinigung: Viel Erfolg!', 'success')
+    end
+end)
+
+-- Tablet toggle
+RegisterNetEvent('qb-citycleaning:server:toggleDuty', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    if Player.PlayerData.job.name == Config.Job then
+        Player.Functions.SetJob('unemployed', 0)
+        TriggerClientEvent('QBCore:Notify', src, 'Du bist nicht mehr im Dienst.', 'error')
+    else
+        Player.Functions.SetJob(Config.Job, 0)
+        TriggerClientEvent('QBCore:Notify', src, 'Stadtreinigung: Viel Erfolg!', 'success')
+    end
+end)
+
+-- Reward the player for tasks
+RegisterNetEvent('qb-citycleaning:server:reward', function(task)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player or Player.PlayerData.job.name ~= Config.Job then return end
+
+    local payment = math.random(Config.MinPay, Config.MaxPay)
+    if task == 'graffiti' then payment = payment + 20 end
+    Player.Functions.AddMoney('cash', payment, 'city-cleaning')
+    TriggerClientEvent('QBCore:Notify', src, ('Du hast $%s erhalten.'):format(payment), 'success')
+end)
+
+-- Bonus for clearing all tasks
+RegisterNetEvent('qb-citycleaning:server:bonus', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player or Player.PlayerData.job.name ~= Config.Job then return end
+    Player.Functions.AddMoney('cash', Config.BonusPay, 'city-cleaning-bonus')
+    TriggerClientEvent('QBCore:Notify', src, ('Bonus $%s für saubere Arbeit!'):format(Config.BonusPay), 'success')
+end)


### PR DESCRIPTION
## Summary
- add depot tablet to start duty, spawn vehicles, and manage uniforms
- support tasks for picking up trash and removing graffiti with bonus payout
- document installation and usage for the expanded job

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e5a32f54832aa740ae97d42fe59a